### PR TITLE
Collapsed log counting; performance improvements

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -81,17 +81,17 @@ namespace Consolation
         readonly Rect titleBarRect = new Rect(0, 0, 10000, 20);
         Rect windowRect = new Rect(margin, margin, Screen.width - (margin * 2), Screen.height - (margin * 2));
 
-        void OnEnable()
+        void OnEnable ()
         {
             Application.logMessageReceived += HandleLog;
         }
 
-        void OnDisable()
+        void OnDisable ()
         {
             Application.logMessageReceived -= HandleLog;
         }
 
-        void Update()
+        void Update ()
         {
             if (Input.GetKeyDown(toggleKey)) {
                 visible = !visible;
@@ -102,7 +102,7 @@ namespace Consolation
             }
         }
 
-        void OnGUI()
+        void OnGUI ()
         {
             if (!visible) {
                 return;
@@ -115,7 +115,7 @@ namespace Consolation
         /// Displays a window that lists the recorded logs.
         /// </summary>
         /// <param name="windowID">Window ID.</param>
-        void DrawConsoleWindow(int windowID)
+        void DrawConsoleWindow (int windowID)
         {
             DrawLogsList();
             DrawToolbar();
@@ -127,35 +127,35 @@ namespace Consolation
         /// <summary>
         /// Displays a scrollable list of logs.
         /// </summary>
-        void DrawLogsList()
+        void DrawLogsList ()
         {
             scrollPosition = GUILayout.BeginScrollView(scrollPosition);
 
             // Used to determine height of accumulated log labels.
             GUILayout.BeginVertical();
 
-            // Iterate through the recorded logs.
-            for (var i = 0; i < logs.Count; i++) {
-                Log log = logs[i];
+                // Iterate through the recorded logs.
+                for (var i = 0; i < logs.Count; i++) {
+                    Log log = logs[i];
 
-                // Skip logs that are filtered out.
-                if (!logTypeFilters[log.type]) {
-                    continue;
-                }
+                    // Skip logs that are filtered out.
+                    if (!logTypeFilters[log.type]) {
+                        continue;
+                    }
 
-                GUI.contentColor = logTypeColors[log.type];
+                    GUI.contentColor = logTypeColors[log.type];
 
-                // Collapse duplicates into a single log entry with a leading counter
-                if (collapse) {
-                    GUILayout.Label(string.Format("({0}) {1}", log.duplicateCount, log.message));
+                    // Collapse duplicates into a single log entry with a leading counter
+                    if (collapse) {
+                        GUILayout.Label(string.Format("({0}) {1}", log.duplicateCount, log.message));
 
-                // Duplicates get individual lines
-                } else {
-                    for (int j = 0; j <= log.duplicateCount; j++) {
-                        GUILayout.Label(log.message);
+                    // Duplicates get individual lines
+                    } else {
+                        for (int j = 0; j <= log.duplicateCount; j++) {
+                            GUILayout.Label(log.message);
+                        }
                     }
                 }
-            }
 
             GUILayout.EndVertical();
             var innerScrollRect = GUILayoutUtility.GetLastRect();
@@ -174,22 +174,22 @@ namespace Consolation
         /// <summary>
         /// Displays options for filtering and changing the logs list.
         /// </summary>
-        void DrawToolbar()
+        void DrawToolbar ()
         {
             GUILayout.BeginHorizontal();
 
-            if (GUILayout.Button(clearLabel)) {
-                logs.Clear();
-            }
+                if (GUILayout.Button(clearLabel)) {
+                    logs.Clear();
+                }
 
-            foreach (LogType logType in Enum.GetValues(typeof(LogType))) {
-                var currentState = logTypeFilters[logType];
-                var label = logType.ToString();
-                logTypeFilters[logType] = GUILayout.Toggle(currentState, label, GUILayout.ExpandWidth(false));
-                GUILayout.Space(20);
-            }
+                foreach (LogType logType in Enum.GetValues(typeof(LogType))) {
+                    var currentState = logTypeFilters[logType];
+                    var label = logType.ToString();
+                    logTypeFilters[logType] = GUILayout.Toggle(currentState, label, GUILayout.ExpandWidth(false));
+                    GUILayout.Space(20);
+                }
 
-            collapse = GUILayout.Toggle(collapse, collapseLabel, GUILayout.ExpandWidth(false));
+                collapse = GUILayout.Toggle(collapse, collapseLabel, GUILayout.ExpandWidth(false));
 
             GUILayout.EndHorizontal();
         }
@@ -200,7 +200,7 @@ namespace Consolation
         /// <param name="message">Message.</param>
         /// <param name="stackTrace">Trace of where the message came from.</param>
         /// <param name="type">Type of message (error, exception, warning, assert).</param>
-        void HandleLog(string message, string stackTrace, LogType type)
+        void HandleLog (string message, string stackTrace, LogType type)
         {
             int lastIndex = logs.Count - 1;
             int duplicateCount = 0;
@@ -238,7 +238,7 @@ namespace Consolation
         /// <param name="innerScrollRect">Rect surrounding scroll view content.</param>
         /// <param name="outerScrollRect">Scroll view container.</param>
         /// <returns>Whether scroll view is scrolled to bottom.</returns>
-        bool IsScrolledToBottom(Rect innerScrollRect, Rect outerScrollRect)
+        bool IsScrolledToBottom (Rect innerScrollRect, Rect outerScrollRect)
         {
             var innerScrollHeight = innerScrollRect.height;
 
@@ -257,7 +257,7 @@ namespace Consolation
         /// <summary>
         /// Moves the scroll view down so that the last log is visible.
         /// </summary>
-        void ScrollToBottom()
+        void ScrollToBottom ()
         {
             scrollPosition = new Vector2(0, Int32.MaxValue);
         }
@@ -265,7 +265,7 @@ namespace Consolation
         /// <summary>
         /// Removes old logs that exceed the maximum number allowed.
         /// </summary>
-        void TrimExcessLogs()
+        void TrimExcessLogs ()
         {
             if (!restrictLogCount) {
                 return;


### PR DESCRIPTION
Code changes
  - Log struct
      - Added int duplicateCount

  - DrawLogsList()
    - Modification of log list removed
    - Duplicate logs added with counted loop
    - When collapse is enabled...
        - Collapsed lines take the format "(#) $log"
      
  - HandleLog()
      - Almost entirely re-written
      - "Duplicate" made more specific: message, stackTrace, and type must all match
      - Sequential duplicate logs are stored as a single struct with a counter

Benefits
  - Adds duplicate line counting!

  - Disabling "collapse" restores duplicate lines

  - Makes DrawLogsList() safer
      - Mutation of object being iterated is dangerous
      - Mutation of non-GUI objects within OnGUI() is bad practice

  - Messages with different log levels are separated

  - Greatly reduces number of structs (assuming console spam is common)
      - CPU cache hits are more likely
      - Smaller memory footprint
      - Saves calls to TrimExcessLogs()