### PR TITLE
Show log messages from all threads with Application.logMessageReceivedThreaded

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -80,12 +80,12 @@ namespace Consolation
 
         void OnDisable()
         {
-            Application.logMessageReceived -= HandleLog;
+            Application.logMessageReceivedThreaded -= HandleLog;
         }
 
         void OnEnable()
         {
-            Application.logMessageReceived += HandleLog;
+            Application.logMessageReceivedThreaded += HandleLog;
         }
 
         void OnGUI()


### PR DESCRIPTION
According to the documentation on Application.logMessageReceivedThreaded:

"Event that is fired if a log message is received.
This event will be triggered regardless of whether the [message] comes in on the main thread or not. This means that the handler code has to be thread-safe. It may be invoked from different threads and may be invoked in parallel. Make sure to only access Unity APIs from your handlers that are allowed to be called from threads other than the main thread.
Note that it is not necessary to subscribe to both Application.logMessageReceived and Application.logMessageReceivedThreaded. The multi-threaded variant will also be called for messages on the main thread."

https://docs.unity3d.com/ScriptReference/Application-logMessageReceivedThreaded.html

This is supported in Unity 5.0 and 2017.x.