### PR TITLE
require touches along with shaking

### DIFF
--- a/Console.cs
+++ b/Console.cs
@@ -28,6 +28,11 @@ namespace Consolation
         /// Whether to open the window by shaking the device (mobile-only).
         /// </summary>
         public bool shakeToOpen = true;
+        
+        /// <summary>
+        /// Also require touches while shaking to avoid accidental shakes.
+        /// </summary>
+        public bool shakeRequiresTouch = false;
 
         /// <summary>
         /// The (squared) acceleration above which the window should open.
@@ -136,9 +141,11 @@ namespace Consolation
                 isVisible = !isVisible;
             }
 
-            if (shakeToOpen && Input.touchCount > 2 && Input.acceleration.sqrMagnitude > shakeAcceleration)
+            if (shakeToOpen &&
+                (!shakeRequiresTouch || Input.touchCount > 2) &&
+                Input.acceleration.sqrMagnitude > shakeAcceleration)
             {
-                isVisible = true;
+                isVisible = !isVisible;
             }
         }
 

--- a/Console.cs
+++ b/Console.cs
@@ -8,7 +8,7 @@ namespace Consolation
     /// <summary>
     /// A console to display Unity's debug logs in-game.
     ///
-    /// Version: 1.1.0
+    /// Version: 1.1.1
     /// </summary>
     class Console : MonoBehaviour
     {

--- a/Console.cs
+++ b/Console.cs
@@ -136,7 +136,7 @@ namespace Consolation
                 isVisible = !isVisible;
             }
 
-            if (shakeToOpen && Input.acceleration.sqrMagnitude > shakeAcceleration)
+            if (shakeToOpen && Input.touchCount > 2 && Input.acceleration.sqrMagnitude > shakeAcceleration)
             {
                 isVisible = true;
             }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ the game itself. This is especially useful on mobile devices.
 
 Attach this script to a game object. The window can be opened with a
 configurable hotkey (defaults to backtick). Alternatively, enable shake-to-open
-in the Inspector to open the console on mobile devices.
+in the Inspector to open the console on mobile devices (shake while
+touching the screen with 3 or more fingers).
 
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ the game itself. This is especially useful on mobile devices.
 
 Attach this script to a game object. The window can be opened with a
 configurable hotkey (defaults to backtick). Alternatively, enable shake-to-open
-in the Inspector to open the console on mobile devices (shake while
-touching the screen with 3 or more fingers).
+in the Inspector to open the console on mobile devices (with an option to
+prevent accidental shakes by requiring 3 or more fingers on the screen).
 
 
 ## Compatibility


### PR DESCRIPTION
Ignore this change if you don't want it, but I found it to be a big improvement. Instead of only shaking on mobile, I made it require 3 or more fingers on the screen while shaking. The reason for this was that testers kept opening the console by accident.